### PR TITLE
Add MUI theme and CssBaseline

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,13 +1,23 @@
 import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
 import { TestPage } from './Test/Page';
+import { ThemeProvider, CssBaseline, createTheme } from '@mui/material';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});
 
 export function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Link to="/test">Go to Test Page</Link>} />
-        <Route path="/test" element={<TestPage />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Link to="/test">Go to Test Page</Link>} />
+          <Route path="/test" element={<TestPage />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
Summary
===
The MUI app should be wrapped with a theme provider, and also use `CssBaseline` to normalize the browser style.

Changes
===
- Add `ThemeProvider` and `CssBaseline`
- Convert to dark mode
